### PR TITLE
Fix typo in README description

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
   - Dockerfile with multistage, build binary and create image
 
 ### Description
-API REST that consulting a database H2 in memory, in the proccess
+API REST that consulting a database H2 in memory, in the process
 get the information with different modes to Query
 
 ### URL endpoints


### PR DESCRIPTION
## Summary
- fix a spelling mistake in README description section

## Testing
- `grep -n "proccess" -n README.md`


------
https://chatgpt.com/codex/tasks/task_e_6863d9a9c5b08321a1398229de541a72